### PR TITLE
Allow use of pip requirements files

### DIFF
--- a/vampire/build.py
+++ b/vampire/build.py
@@ -25,7 +25,7 @@ class Directory(object):
 
 class PythonBuild(object):
     """
-    Class abstracting a Python 
+    Class abstracting a Python
     build.
     """
     def __init__(self, version, target, host):

--- a/vampire/build.py
+++ b/vampire/build.py
@@ -37,7 +37,7 @@ class PythonBuild(object):
         logger.debug('Host: %s' % host)
         self.version = version
         self.nice_version = '.'.join(list(self.version))
-        self.target = target
+        self.target = os.path.abspath(target)
         self.host = host
         self.temporary_directory = '/tmp'
         self.package_url = 'https://www.python.org/ftp/python/%s/Python-%s.tar.xz' % (

--- a/vmp
+++ b/vmp
@@ -32,6 +32,7 @@ def main():
                         default=os.path.join(os.path.expanduser('~'), 'python'))
     parser.add_argument('--host', help='Specify the target host', default='localhost')
     parser.add_argument('--packages', help='Specify required packages', nargs='+')
+    parser.add_argument('--requirements', help='Specify pip requirements file')
     parser.add_argument('--DEBUG', help='Switch logger to debug output', action='store_true', default=False)
     parser.add_argument('--VERSION', help='Print Vampire version and exit', action='store_true', default=False)
     args = parser.parse_args()
@@ -52,7 +53,8 @@ def main():
 
     packages = PythonPackages(
         build,
-        args.packages
+        packages=args.packages,
+        requirements=args.requirements
     )
     packages()
     logger.info('Finished.')


### PR DESCRIPTION
Made '--packages' optional, and added --requirements to pass pip a requirements file as produced by 'pip freeze' somewhere else.

os.path.abspath on 'target' variable to allow use of relative directory names on the commandline.
