### PR TITLE
--list and --listall for finding versions to install

### DIFF
--- a/vampire/build.py
+++ b/vampire/build.py
@@ -50,7 +50,7 @@ class PythonBuild(object):
         self.package_name = os.path.splitext(os.path.splitext(self.package_name_zipped)[0])[0]
         self.package_path = os.path.join(self.temporary_directory, self.package_name_zipped)
 
-        self.is_three = int(self.version.replace('.', '')) > 300
+        self.is_three = self.version.startswith('3')
 
     def __call__(self):
         """

--- a/vampire/build.py
+++ b/vampire/build.py
@@ -36,7 +36,10 @@ class PythonBuild(object):
         logger.debug('Target: %s' % target)
         logger.debug('Host: %s' % host)
         self.version = version
-        self.nice_version = '.'.join(list(self.version))
+        if '.' not in self.version:
+            self.nice_version = '.'.join(list(self.version))
+        else:
+            self.nice_version = self.version
         self.target = os.path.abspath(target)
         self.host = host
         self.temporary_directory = '/tmp'

--- a/vampire/versions.py
+++ b/vampire/versions.py
@@ -2,6 +2,7 @@
 from urllib.request import urlopen
 from html.parser import HTMLParser
 from collections import defaultdict
+import requests
 
 class PythonIndexParser(HTMLParser):
     def __init__(self):
@@ -31,8 +32,19 @@ def available_versions(recent=False):
     foo = download.read()
     parser.feed(str(foo))
 
-    versions = parser.get_versions()
+    versions = sorted(parser.get_versions())
 
+    # alphas and release candidates get their own directory, but add to the 
+    # numeric version numbers found in the directories.
+    # We only care about these in the most recently two or three directories
+    check_versions = list(versions[-3:])
+    for version in check_versions:
+        url = 'https://www.python.org/ftp/python/{0}/Python-{0}.tar.xz'.format(version)
+        header_info = requests.head(url)
+        if header_info.status_code != 200:
+            versions.remove(version)
+
+    # --listall was used, return all values
     if recent is False:
         return versions
 

--- a/vampire/versions.py
+++ b/vampire/versions.py
@@ -1,0 +1,67 @@
+
+from urllib.request import urlopen
+from html.parser import HTMLParser
+from collections import defaultdict
+
+class PythonIndexParser(HTMLParser):
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.versions = list()
+
+    def handle_starttag(self, tag, attrs):
+        if tag != 'a':
+            return
+        for attr in attrs:
+            if 'href' in attr and len(attr) > 1:
+                version = attr[1].rstrip('/')
+                if version[:1].isdigit():
+                    self.versions.append(version)
+
+    def get_versions(self):
+        return self.versions
+
+def available_versions(recent=False):
+    """ Acquire list of available python versions
+    :param recent: Only show versions updated in last few years
+    """
+    package_url = "https://www.python.org/ftp/python/"
+
+    download = urlopen(package_url)
+    parser = PythonIndexParser()
+    foo = download.read()
+    parser.feed(str(foo))
+
+    versions = parser.get_versions()
+
+    if recent is False:
+        return versions
+
+    """
+    Produce a list of the highest available MICRO version for each
+    MAJOR.MINOR group. Standard max check, indexed by MAJOR.MINOR
+    """
+    version_filter = defaultdict(int)
+    for version in versions:
+        vsplit = version.split('.')
+        # assumpion: there will always be a major and minor version, based
+        # on existence of '2.0'
+        majorminor = "{}.{}".format(vsplit[0], vsplit[1])
+        if len(vsplit) < 3:
+            micro = 0
+        else:
+            micro = int(vsplit[2])
+        if version_filter[majorminor] < micro:
+            version_filter[majorminor] = micro
+
+    versions = list()
+    for version in version_filter:
+        # 0 wasn't in the original, so don't put it back
+        if version_filter[version] == 0:
+            versions.append(version)
+        else:
+            versions.append("{}.{}".format(version, version_filter[version]))
+
+    return sorted(versions)
+
+if __name__ == '__main__':
+    print(available_versions(recent=True))

--- a/vmp
+++ b/vmp
@@ -53,7 +53,8 @@ def main():
         sys.exit(0)
 
     if args.listall:
-        print("All known and available Python versions:")
+        print("All available Python versions")
+        print("(Excluding early releases")
         print("\n".join(available_versions()))
         sys.exit(0)
 

--- a/vmp
+++ b/vmp
@@ -3,8 +3,10 @@ import os
 import sys
 import logging
 import argparse
+import platform
 from vampire.build import PythonBuild
 from vampire.packages import PythonPackages
+from vampire.versions import available_versions
 
 
 logging.basicConfig(
@@ -27,7 +29,7 @@ def main():
     Parse arguments and execute.
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('--version', help='Specify the Python version', required=True)
+    parser.add_argument('--version', help='Specify the Python version', default=platform.python_version())
     parser.add_argument('--target', help='Specify the target directory',
                         default=os.path.join(os.path.expanduser('~'), 'python'))
     parser.add_argument('--host', help='Specify the target host', default='localhost')
@@ -35,6 +37,8 @@ def main():
     parser.add_argument('--requirements', help='Specify pip requirements file')
     parser.add_argument('--DEBUG', help='Switch logger to debug output', action='store_true', default=False)
     parser.add_argument('--VERSION', help='Print Vampire version and exit', action='store_true', default=False)
+    parser.add_argument('--list', help='Print available minor Python branches', action='store_true', default=False)
+    parser.add_argument('--listall', help='Print all known available Python versions', action='store_true', default=False)
     args = parser.parse_args()
 
     if args.VERSION:
@@ -42,6 +46,16 @@ def main():
 
     if args.DEBUG:
         logger.setLevel(logging.DEBUG)
+
+    if args.list:
+        print("Available Python versions:")
+        print("\n".join(available_versions(recent=True)))
+        sys.exit(0)
+
+    if args.listall:
+        print("All known and available Python versions:")
+        print("\n".join(available_versions()))
+        sys.exit(0)
 
     logger.info('Starting Vampire.')
     build = PythonBuild(


### PR DESCRIPTION
--list now displays installable end-branch python versions, and --listall displays all known ones.
--version made optional (default to currently running python) in order to enable this.

To do: think about how to best install release candidate and alpha versions if requested. These are currently filtered out, as they don't match the n.n.n version string. 
